### PR TITLE
Fixed accessing undefined when no arguments are returned

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,8 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     if (pss.length === 1) {
-      vscode.window.showInformationMessage(`Matched process with pid '${pss[0].pid}'. Command: '${pss[0].command} ${pss[0].arguments.join(' ')}'`);
+      const args = pss[0].arguments ? pss[0].arguments.join(' ') : '';
+      vscode.window.showInformationMessage(`Matched process with pid '${pss[0].pid}'. Command: '${pss[0].command} ${args}'`);
       return pss[0].pid;
     }
 


### PR DESCRIPTION
# Issue
When trying to match a program by name which was started with no command line arguments an exception is raised. 
launch.json example:
```json
"inputs": [
        {
            "id": "PluginHostMatcher",
            "type": "command",
            "command": "process-matcher.match",
            "args": {
                "program": "AudioPluginHost.exe"
            }
        } 
```
# Reason
If no arguments were passed to the program `ps.lookup()` returns an object with no arguments. Trying to call `pss[0].arguments.join(' ')` throws an error.

# Fix 
Check if `pss[0].arguments` has a value
```js
const args = pss[0].arguments ? pss[0].arguments.join(' ') : '';
vscode.window.showInformationMessage(`Matched process with pid '${pss[0].pid}'. Command: '${pss[0].command} ${args}'`);
```

