### PR TITLE
Replace `ps-node` with `find-process` to remove WMIC dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "process-matcher",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "process-matcher",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
-        "ps-node": "^0.1.6"
+        "find-process": "^1.4.7"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.6",
@@ -1025,7 +1025,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1346,7 +1345,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1362,7 +1360,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -1503,7 +1500,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1514,8 +1510,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1543,11 +1538,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
-    },
-    "node_modules/connected-domain": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/connected-domain/-/connected-domain-1.0.0.tgz",
-      "integrity": "sha512-lHlohUiJxlpunvDag2Y0pO20bnvarMjnrdciZeuJUqRwrf/5JHNhdpiPIr5GQ8IkqrFj5TDMQwcCjblGo1oeuA=="
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2175,6 +2165,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-process": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmmirror.com/find-process/-/find-process-1.4.11.tgz",
+      "integrity": "sha512-mAOh9gGk9WZ4ip5UjV0o6Vb4SrfnAmtsFNzkMRH9HQiFXVQnDyQFrSHTK5UoG6E+KV+s+cIznbtwpfN41l2nFA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "~4.1.2",
+        "commander": "^12.1.0",
+        "loglevel": "^1.9.2"
+      },
+      "bin": {
+        "find-process": "bin/find-process.js"
+      }
+    },
+    "node_modules/find-process/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmmirror.com/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2488,7 +2501,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3153,6 +3165,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmmirror.com/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/lru-cache": {
@@ -3840,14 +3865,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "node_modules/ps-node": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ps-node/-/ps-node-0.1.6.tgz",
-      "integrity": "sha512-w7QJhUTbu70hpDso0YXDRNKCPNuchV8UTUZsAv0m7Qj5g85oHOJfr9drA1EjvK4nQK/bG8P97W4L6PJ3IQLoOA==",
-      "dependencies": {
-        "table-parser": "^0.1.3"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -4379,14 +4396,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/table-parser": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/table-parser/-/table-parser-0.1.3.tgz",
-      "integrity": "sha512-LCYeuvqqoPII3lzzYaXKbC3Forb+d2u4bNwhk/9FlivuGRxPE28YEWAYcujeSlLLDlMfvy29+WPybFJZFiKMYg==",
-      "dependencies": {
-        "connected-domain": "^1.0.0"
       }
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "vscode-test": "^1.6.1"
   },
   "dependencies": {
-    "ps-node": "^0.1.6"
+    "find-process": "^1.4.7"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-const find = require('find-process');
+import find from 'find-process';
 
 interface MatchOptions {
   program: string;
@@ -20,15 +20,15 @@ async function getProcessInfo(options: MatchOptions): Promise<ProcessInfo[]> {
     
     // Filter by args if provided
     if (options.args && options.args.length > 0) {
-      filteredProcesses = processes.filter((proc: any) => {
+      filteredProcesses = processes.filter((proc) => {
         const cmd = proc.cmd || '';
         return options.args.every(arg => cmd.includes(arg));
       });
     }
     
     // Convert to ProcessInfo format
-    return filteredProcesses.map((proc: any) => ({
-      pid: String(proc.pid),
+    return filteredProcesses.map((proc) => ({
+      pid: proc.pid,
       command: proc.name,
       arguments: proc.cmd ? proc.cmd.split(' ').slice(1) : []
     }));
@@ -49,7 +49,7 @@ export function activate(context: vscode.ExtensionContext) {
     if (pss.length === 1) {
       const args = pss[0].arguments ? pss[0].arguments.join(' ') : '';
       vscode.window.showInformationMessage(`Matched process with pid '${pss[0].pid}'. Command: '${pss[0].command} ${args}'`);
-      return pss[0].pid;
+      return pss[0].pid.toString();
     }
 
     const quickPickItems: vscode.QuickPickItem[] = pss.map((ps) => {


### PR DESCRIPTION
**Issue**  
`ps-node` relies on `wmic`, which is deprecated on modern Windows, causing process lookup failures.

**Reason**  
`wmic` is unavailable in newer Windows versions, making `ps-node` unreliable. A replacement is needed for better compatibility.

**Fix**  
- Replaced `ps-node` with `find-process` in `package.json` and `src/extension.ts`.
- Updated `getProcessInfo` to use `find-process` for process lookup and implemented basic argument filtering.
- Adjusted `package-lock.json` to reflect the new dependency.

**Potential Issue**  
`find-process` does not support advanced argument matching like `ps-node`. The current implementation uses simple substring matching, which may lead to inaccuracies in some cases.

**Changed Files**  
- `package.json`
- `package-lock.json`
- `src/extension.ts`